### PR TITLE
feat: texture support, frame export & streaming

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,11 @@ It works in both **WebGL1 and WebGL2** contexts, with automatic fallback and det
 - [Sandbox Shaders](#sandbox-shaders)
 - [Hooks](#hooks)
   - [Self-removing hooks](#self-removing-hooks)
+- [Textures](#textures)
+  - [Texture options](#texture-options)
+  - [Dynamic textures](#dynamic-textures)
+- [Export](#export)
+  - [Streaming](#streaming)
 - [Chaining](#chaining)
 - [Error handling](#error-handling)
 - [Vue integration](#vue-integration)
@@ -260,7 +265,10 @@ Sandbox.defineModule("my_gradient", gradientSource, {
   myFunc: {
     colors: {
       uniform: "u_colors",
-      default: [[1, 0, 0], [0, 0, 1]],
+      default: [
+        [1, 0, 0],
+        [0, 0, 1],
+      ],
     },
     speed: { uniform: "u_speed", default: 1.0 },
   },
@@ -276,7 +284,10 @@ Sandbox.defineModule("my_module", source, {
   default: {
     colors: {
       uniform: "u_colors",
-      default: [[1, 0, 0], [0, 0, 1]],
+      default: [
+        [1, 0, 0],
+        [0, 0, 1],
+      ],
     },
     speed: { uniform: "u_speed", default: 1.0 },
   },
@@ -336,6 +347,124 @@ sandbox.hook(({ time }) => {
 
 This is how `pauseAt()` works internally — it's hooks all the way down.
 
+## Textures
+
+Sandbox supports textures as `sampler2D` uniforms. Pass any image, canvas, or video element and Sandbox takes care of the WebGL plumbing — creating the texture, binding it to a texture unit, and setting the sampler uniform.
+
+```ts
+const img = new Image();
+img.src = "photo.jpg";
+img.onload = () => {
+  sandbox.setTexture("u_texture", img);
+};
+```
+
+Then sample it in your shader:
+
+```glsl
+uniform sampler2D u_texture;
+
+void main() {
+  vec4 color = texture2D(u_texture, v_texcoord);
+  gl_FragColor = color;
+}
+```
+
+Multiple textures work the same way — each gets its own texture unit automatically:
+
+```ts
+sandbox.setTexture("u_photo", photoImg);
+sandbox.setTexture("u_mask", maskImg);
+```
+
+You can also set textures upfront via options:
+
+```ts
+Sandbox.create(canvas, {
+  fragment: shader,
+  textures: {
+    u_photo: photoImg,
+    u_mask: { source: maskImg, wrap: "repeat" },
+  },
+});
+```
+
+### Texture options
+
+Each texture accepts optional configuration for wrapping, filtering, and orientation:
+
+```ts
+sandbox.setTexture("u_texture", img, {
+  wrap: "repeat", // both axes (default: "clamp")
+  minFilter: "nearest", // pixelated look (default: "linear")
+  flipY: false, // disable vertical flip (default: true)
+});
+```
+
+| Option      | Values                             | Default    |
+| ----------- | ---------------------------------- | ---------- |
+| `wrap`      | `"clamp"`, `"repeat"`, `"mirror"`  | `"clamp"`  |
+| `wrapS`     | same (overrides `wrap` for S axis) | `wrap`     |
+| `wrapT`     | same (overrides `wrap` for T axis) | `wrap`     |
+| `minFilter` | `"nearest"`, `"linear"`            | `"linear"` |
+| `magFilter` | `"nearest"`, `"linear"`            | `"linear"` |
+| `flipY`     | `boolean`                          | `true`     |
+| `dynamic`   | `boolean`                          | auto       |
+
+### Dynamic textures
+
+When you pass a video element, Sandbox automatically re-uploads pixels every frame so the texture stays in sync with playback. This also works for animated canvases — just set `dynamic: true`:
+
+```ts
+// Video — dynamic by default
+sandbox.setTexture("u_video", videoElement);
+
+// Animated canvas — opt in
+sandbox.setTexture("u_canvas", canvasElement, { dynamic: true });
+```
+
+To remove a texture and free its GPU memory:
+
+```ts
+sandbox.removeTexture("u_texture");
+```
+
+## Export
+
+Sandbox can export the current frame as an image or blob — useful for saving screenshots, generating thumbnails, or uploading processed images to a server.
+
+```ts
+// Data URL (synchronous)
+const url = sandbox.renderAt(1.5).exportAsURL("image/png");
+
+// Blob (async) — perfect for server uploads
+const blob = await sandbox.renderAt(1.5).exportAsBlob("image/jpeg", 0.9);
+await fetch("/upload", { method: "POST", body: blob });
+
+// HTMLImageElement
+const img = sandbox.renderAt(1.5).exportAsImage("image/png");
+document.body.appendChild(img);
+```
+
+> [!NOTE]
+> Export methods work reliably after `render()` or `renderAt()`. If you need to capture frames during an active render loop, set `preserveDrawingBuffer: true` in options.
+
+### Streaming
+
+For real-time use cases like video calls or recording, Sandbox can expose the canvas as a `MediaStream`:
+
+```ts
+// WebRTC — send shader output to a video call
+const stream = sandbox.stream(30);
+peerConnection.addTrack(stream.getVideoTracks()[0], stream);
+
+// Recording — save as video file
+const recorder = new MediaRecorder(sandbox.stream(30));
+recorder.start();
+```
+
+This opens up workflows like **webcam → texture → shader effect → video call** with just a few lines of code.
+
 ## Chaining
 
 Every method returns `this`, so you can chain calls for clean, expressive code:
@@ -373,6 +502,7 @@ The error object includes useful details:
 | `PROGRAM_ERROR`    | Shader program linking failed                                                         |
 | `VALIDATION_ERROR` | Vertex/fragment shader version mismatch                                               |
 | `MODULE_ERROR`     | Module not found, method not found, forbidden name, or duplicate definition           |
+| `TEXTURE_ERROR`    | Texture creation failed or texture unit limit exceeded                                |
 | `UNKNOWN_ERROR`    | Unexpected error in callbacks (onLoad, hooks)                                         |
 
 ## Vue integration
@@ -443,6 +573,7 @@ interface SandboxOptions {
   onAfterRender?: HookCallback | null;
   uniforms?: UniformSchema;
   modules?: Record<string, Record<string, AnyUniformValue>>;
+  textures?: TextureSchema;
 }
 ```
 
@@ -462,12 +593,13 @@ interface SandboxOptions {
 | `onAfterRender`         | —               | Hook after each frame                          |
 | `uniforms`              | —               | Initial uniform values                         |
 | `modules`               | —               | Configure module options per imported function |
+| `textures`              | —               | Initial textures to bind to sampler uniforms   |
 
 ## Limitations (by design)
 
-- No textures (planned for future)
 - No multi‑pass rendering
 - No 3D scene graph
+- No custom geometry (fullscreen quad only)
 
 If you need a full engine, reach for three.js. For clean shader‑only effects, Sandbox is a joy to use.
 

--- a/src/errors/base.ts
+++ b/src/errors/base.ts
@@ -4,6 +4,7 @@ export type SandboxErrorCode =
   | "PROGRAM_ERROR"
   | "SHADER_ERROR"
   | "MODULE_ERROR"
+  | "TEXTURE_ERROR"
   | "UNKNOWN_ERROR";
 
 export class SandboxError extends Error {

--- a/src/errors/index.ts
+++ b/src/errors/index.ts
@@ -3,4 +3,5 @@ export * from "./context";
 export * from "./shader";
 export * from "./module";
 export * from "./program";
+export * from "./texture";
 export * from "./unknown";

--- a/src/errors/texture.ts
+++ b/src/errors/texture.ts
@@ -1,0 +1,24 @@
+import { SandboxError } from "./base";
+
+export class SandboxTextureCreationError extends SandboxError {
+  public readonly name = "SandboxTextureCreationError";
+  constructor(public readonly textureName: string) {
+    super(
+      `Failed to create WebGL texture for "${textureName}".`,
+      "TEXTURE_ERROR",
+    );
+  }
+}
+
+export class SandboxTextureUnitLimitError extends SandboxError {
+  public readonly name = "SandboxTextureUnitLimitError";
+  constructor(
+    public readonly textureName: string,
+    public readonly maxUnits: number,
+  ) {
+    super(
+      `Cannot bind texture "${textureName}": all ${maxUnits} texture units are in use.`,
+      "TEXTURE_ERROR",
+    );
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,9 @@ import type {
   ModuleDefinition,
   ResolvedSandboxOptions,
   SandboxOptions,
+  TextureOptions,
+  TextureSchema,
+  TextureSource,
   UniformSchema,
   WebGLVersion,
 } from "./types";
@@ -152,6 +155,7 @@ export class Sandbox {
       onAfterRender: null,
       uniforms: {},
       modules: {},
+      textures: {},
     };
 
     if (options?.vertex) this.usingCustomVertex = true;
@@ -311,6 +315,40 @@ export class Sandbox {
    */
   getUniform<T extends AnyUniformValue>(name: string): T | undefined {
     return this.engine.getUniform<T>(name);
+  }
+
+  /**
+   * Set a texture for a sampler2D uniform.
+   * @example
+   * sandbox.setTexture("u_texture", imageElement);
+   * sandbox.setTexture("u_texture", imageElement, { wrap: "repeat" });
+   */
+  setTexture(name: string, source: TextureSource, options?: TextureOptions): this {
+    this.engine.texture(name, source, options);
+    return this;
+  }
+
+  /**
+   * Set multiple textures at once.
+   * @example
+   * sandbox.setTextures({
+   *   u_texture: imageElement,
+   *   u_detail: { source: detailImg, wrap: "repeat" },
+   * });
+   */
+  setTextures(textures: TextureSchema): this {
+    this.engine.texturesFromSchema(textures);
+    return this;
+  }
+
+  /**
+   * Remove a texture and free its GPU resources.
+   * @example
+   * sandbox.removeTexture("u_texture");
+   */
+  removeTexture(name: string): this {
+    this.engine.removeTexture(name);
+    return this;
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -323,7 +323,11 @@ export class Sandbox {
    * sandbox.setTexture("u_texture", imageElement);
    * sandbox.setTexture("u_texture", imageElement, { wrap: "repeat" });
    */
-  setTexture(name: string, source: TextureSource, options?: TextureOptions): this {
+  setTexture(
+    name: string,
+    source: TextureSource,
+    options?: TextureOptions,
+  ): this {
     this.engine.texture(name, source, options);
     return this;
   }
@@ -564,6 +568,75 @@ export class Sandbox {
    */
   get canvas(): HTMLCanvasElement {
     return this.canvasEl;
+  }
+
+  /**
+   * Export current frame as a data URL string.
+   * Requires `preserveDrawingBuffer: true` if called while playing.
+   * @example
+   * const url = sandbox.renderAt(1.5).exportAsURL("image/png");
+   */
+  exportAsURL(
+    type: "image/png" | "image/jpeg" = "image/png",
+    quality?: number,
+  ): string {
+    return this.canvas.toDataURL(type, quality);
+  }
+
+  /**
+   * Export current frame as a Blob.
+   * Requires `preserveDrawingBuffer: true` if called while playing.
+   * @example
+   * const blob = await sandbox.renderAt(1.5).exportAsBlob("image/png");
+   */
+  exportAsBlob(
+    type: "image/png" | "image/jpeg" = "image/png",
+    quality?: number,
+  ): Promise<Blob> {
+    return new Promise((resolve, reject) => {
+      this.canvas.toBlob(
+        (blob) => {
+          if (blob) {
+            resolve(blob);
+          } else {
+            reject(new Error("Failed to create blob from canvas."));
+          }
+        },
+        type,
+        quality,
+      );
+    });
+  }
+
+  /**
+   * Export current frame as an HTMLImageElement.
+   * Requires `preserveDrawingBuffer: true` if called while playing.
+   * @example
+   * const img = sandbox.renderAt(1.5).exportAsImage("image/png");
+   * img.onload = () => document.body.appendChild(img);
+   */
+  exportAsImage(
+    type: "image/png" | "image/jpeg" = "image/png",
+    quality?: number,
+  ): HTMLImageElement {
+    const img = new Image();
+    img.src = this.exportAsURL(type, quality);
+    return img;
+  }
+
+  /**
+   * Capture the canvas as a MediaStream for video calls or recording.
+   * @example
+   * // WebRTC video call
+   * const stream = sandbox.stream(30);
+   * peerConnection.addTrack(stream.getVideoTracks()[0], stream);
+   *
+   * @example
+   * // Record to video file
+   * const recorder = new MediaRecorder(sandbox.stream(30));
+   */
+  stream(fps?: number): MediaStream {
+    return this.canvasEl.captureStream(fps);
   }
 
   /**

--- a/src/tools/texture.ts
+++ b/src/tools/texture.ts
@@ -1,0 +1,210 @@
+import type {
+  ResolvedTextureOptions,
+  TextureOptions,
+  TextureSource,
+  TextureWrap,
+  WebGLContext,
+} from "../types";
+
+/**
+ * Handles a single WebGL texture.
+ * Manages texture creation, pixel upload, binding, and location caching.
+ * Mirrors the Uniform class pattern for consistency.
+ */
+export default class Texture {
+  readonly name: string;
+
+  private gl: WebGLContext;
+  private texture: WebGLTexture | null = null;
+  private location: WebGLUniformLocation | null = null;
+  private locationResolved = false;
+  private source: TextureSource;
+  private options: ResolvedTextureOptions;
+  private dynamicOverride: boolean | undefined;
+  private needsUpload = true;
+  private needsReupload = false;
+
+  constructor(
+    gl: WebGLContext,
+    name: string,
+    source: TextureSource,
+    options?: TextureOptions,
+  ) {
+    this.gl = gl;
+    this.name = name;
+    this.source = source;
+    this.dynamicOverride = options?.dynamic;
+    this.options = Texture.resolveOptions(source, options);
+    this.needsReupload = this.options.dynamic;
+  }
+
+  /**
+   * Update the texture source.
+   * Marks texture for re-upload on next bind.
+   * Respects the original `dynamic` option if explicitly set, otherwise re-infers from source type.
+   */
+  setSource(source: TextureSource): void {
+    this.source = source;
+    this.needsUpload = true;
+    this.needsReupload = this.dynamicOverride ?? Texture.isDynamicSource(source);
+  }
+
+  /**
+   * Resolve and cache uniform location from program.
+   * Returns null if the sampler uniform doesn't exist in the shader.
+   */
+  resolveLocation(
+    gl: WebGLContext,
+    program: WebGLProgram,
+  ): WebGLUniformLocation | null {
+    if (!this.locationResolved) {
+      this.location = gl.getUniformLocation(program, this.name);
+      this.locationResolved = true;
+    }
+    return this.location;
+  }
+
+  /**
+   * Invalidate cached location (call when program changes).
+   */
+  invalidateLocation(): void {
+    this.location = null;
+    this.locationResolved = false;
+  }
+
+  /**
+   * Bind texture to a texture unit and set the sampler uniform.
+   * @param program - Current WebGL program (for location resolution)
+   * @param unit - Texture unit index (0, 1, 2, ...)
+   */
+  upload(program: WebGLProgram, unit: number): void {
+    const gl = this.gl;
+    const location = this.resolveLocation(gl, program);
+
+    // Sampler uniform doesn't exist in shader — silently skip
+    if (location === null) {
+      return;
+    }
+
+    // Create texture object if needed
+    if (!this.texture) {
+      this.texture = gl.createTexture();
+      if (!this.texture) return;
+      this.needsUpload = true;
+    }
+
+    // Activate texture unit and bind
+    gl.activeTexture(gl.TEXTURE0 + unit);
+    gl.bindTexture(gl.TEXTURE_2D, this.texture);
+
+    // Upload pixel data if needed (first time, source changed, or dynamic source)
+    if (this.needsUpload || this.needsReupload) {
+      this.uploadPixels();
+      this.needsUpload = false;
+    }
+
+    // Set sampler uniform to texture unit index
+    gl.uniform1i(location, unit);
+  }
+
+  /**
+   * Cleanup WebGL texture resource.
+   */
+  destroy(): void {
+    if (this.texture) {
+      this.gl.deleteTexture(this.texture);
+      this.texture = null;
+    }
+    this.location = null;
+    this.locationResolved = false;
+  }
+
+  /**
+   * Upload pixel data from source and apply texture parameters.
+   */
+  private uploadPixels(): void {
+    const gl = this.gl;
+
+    // Flip Y (images have origin at top-left, WebGL at bottom-left)
+    gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, this.options.flipY);
+
+    // Upload pixel data
+    gl.texImage2D(
+      gl.TEXTURE_2D,
+      0,
+      gl.RGBA,
+      gl.RGBA,
+      gl.UNSIGNED_BYTE,
+      this.source,
+    );
+
+    // Apply wrap and filter parameters
+    this.applyParameters();
+  }
+
+  /**
+   * Apply texture wrap and filter parameters.
+   */
+  private applyParameters(): void {
+    const gl = this.gl;
+
+    gl.texParameteri(
+      gl.TEXTURE_2D,
+      gl.TEXTURE_WRAP_S,
+      Texture.resolveWrap(gl, this.options.wrapS),
+    );
+    gl.texParameteri(
+      gl.TEXTURE_2D,
+      gl.TEXTURE_WRAP_T,
+      Texture.resolveWrap(gl, this.options.wrapT),
+    );
+    gl.texParameteri(
+      gl.TEXTURE_2D,
+      gl.TEXTURE_MIN_FILTER,
+      this.options.minFilter === "nearest" ? gl.NEAREST : gl.LINEAR,
+    );
+    gl.texParameteri(
+      gl.TEXTURE_2D,
+      gl.TEXTURE_MAG_FILTER,
+      this.options.magFilter === "nearest" ? gl.NEAREST : gl.LINEAR,
+    );
+  }
+
+  /**
+   * Resolve wrap mode string to WebGL constant.
+   */
+  private static resolveWrap(gl: WebGLContext, wrap: TextureWrap): number {
+    switch (wrap) {
+      case "repeat":
+        return gl.REPEAT;
+      case "mirror":
+        return gl.MIRRORED_REPEAT;
+      case "clamp":
+      default:
+        return gl.CLAMP_TO_EDGE;
+    }
+  }
+
+  /**
+   * Resolve texture options with defaults.
+   */
+  private static resolveOptions(source: TextureSource, options?: TextureOptions): ResolvedTextureOptions {
+    const wrap = options?.wrap ?? "clamp";
+    return {
+      wrap,
+      wrapS: options?.wrapS ?? wrap,
+      wrapT: options?.wrapT ?? wrap,
+      minFilter: options?.minFilter ?? "linear",
+      magFilter: options?.magFilter ?? "linear",
+      flipY: options?.flipY ?? true,
+      dynamic: options?.dynamic ?? Texture.isDynamicSource(source),
+    };
+  }
+
+  /**
+   * Check if a source is dynamic (needs re-upload every frame).
+   */
+  private static isDynamicSource(source: TextureSource): boolean {
+    return source instanceof HTMLVideoElement;
+  }
+}

--- a/src/tools/textures.ts
+++ b/src/tools/textures.ts
@@ -1,0 +1,113 @@
+import type {
+  TextureOptions,
+  TextureSource,
+  WebGLContext,
+} from "../types";
+import Texture from "./texture";
+
+/**
+ * Manages a collection of textures with fluent API.
+ * Assigns texture units sequentially and handles program attachment.
+ * Mirrors the Uniforms class pattern for consistency.
+ */
+export default class Textures {
+  private gl: WebGLContext;
+  private program: WebGLProgram | null = null;
+  private textures: Map<string, Texture> = new Map();
+
+  constructor(gl: WebGLContext) {
+    this.gl = gl;
+  }
+
+  /**
+   * Attach to a WebGL program.
+   * Invalidates all cached locations since they're program-specific.
+   */
+  attachProgram(program: WebGLProgram): this {
+    this.program = program;
+
+    for (const texture of this.textures.values()) {
+      texture.invalidateLocation();
+    }
+
+    return this;
+  }
+
+  /**
+   * Set a texture.
+   * Creates the texture entry if it doesn't exist, updates source if it does.
+   */
+  set(name: string, source: TextureSource, options?: TextureOptions): this {
+    const existing = this.textures.get(name);
+
+    if (existing) {
+      existing.setSource(source);
+    } else {
+      this.textures.set(name, new Texture(this.gl, name, source, options));
+    }
+
+    return this;
+  }
+
+  /**
+   * Get a texture by name.
+   */
+  get(name: string): Texture | undefined {
+    return this.textures.get(name);
+  }
+
+  /**
+   * Check if a texture exists.
+   */
+  has(name: string): boolean {
+    return this.textures.has(name);
+  }
+
+  /**
+   * Remove a texture and free its GPU resources.
+   */
+  delete(name: string): boolean {
+    const texture = this.textures.get(name);
+    if (texture) {
+      texture.destroy();
+      return this.textures.delete(name);
+    }
+    return false;
+  }
+
+  /**
+   * Upload all textures to their respective texture units.
+   * Units are assigned sequentially (0, 1, 2, ...).
+   */
+  uploadAll(): this {
+    if (!this.program) {
+      return this;
+    }
+
+    let unit = 0;
+    for (const texture of this.textures.values()) {
+      texture.upload(this.program, unit);
+      unit++;
+    }
+
+    return this;
+  }
+
+  /**
+   * Get texture count.
+   */
+  get size(): number {
+    return this.textures.size;
+  }
+
+  /**
+   * Cleanup all textures.
+   */
+  destroy(): void {
+    for (const texture of this.textures.values()) {
+      texture.destroy();
+    }
+    this.textures.clear();
+    this.program = null;
+  }
+}

--- a/src/tools/web_gl.ts
+++ b/src/tools/web_gl.ts
@@ -2,6 +2,9 @@ import type {
   AnyUniformValue,
   ClockState,
   ResolvedSandboxOptions,
+  TextureOptions,
+  TextureSchema,
+  TextureSource,
   UniformSchema,
   Vec2,
   WebGLContext,
@@ -17,6 +20,7 @@ import Clock from "./clock";
 import Geometry from "./geometry";
 import Program from "./program";
 import Uniforms from "./uniforms";
+import Textures from "./textures";
 import Hooks from "./hooks";
 import Shader from "./shader";
 import { runtime_modules as RUNTIME_MODULES } from "../globals";
@@ -36,6 +40,7 @@ export default class WebGL {
   private _program: Program;
   private _geometry: Geometry;
   private _uniforms: Uniforms;
+  private _textures: Textures;
   private _clock: Clock;
 
   private _resolution: Vec2 = [1, 1];
@@ -61,6 +66,7 @@ export default class WebGL {
     this._program = new Program(this.gl);
     this._geometry = Geometry.fullscreenQuad(this.gl);
     this._uniforms = new Uniforms(this.gl);
+    this._textures = new Textures(this.gl);
     this._clock = new Clock();
 
     // Apply max FPS if specified
@@ -97,6 +103,11 @@ export default class WebGL {
     // Set initial uniforms
     if (options.uniforms) {
       webgl._uniforms.setMany(options.uniforms);
+    }
+
+    // Set initial textures
+    if (options.textures) {
+      webgl.texturesFromSchema(options.textures);
     }
 
     // Set module default uniform values
@@ -209,6 +220,42 @@ export default class WebGL {
   }
 
   /**
+   * Set a texture.
+   */
+  texture(name: string, source: TextureSource, options?: TextureOptions): this {
+    this._textures.set(name, source, options);
+    return this;
+  }
+
+  /**
+   * Set multiple textures from a schema.
+   */
+  texturesFromSchema(schema: TextureSchema): this {
+    for (const [name, value] of Object.entries(schema)) {
+      if (value instanceof HTMLImageElement ||
+          value instanceof HTMLCanvasElement ||
+          value instanceof HTMLVideoElement ||
+          value instanceof ImageBitmap ||
+          value instanceof ImageData ||
+          value instanceof OffscreenCanvas) {
+        this._textures.set(name, value);
+      } else {
+        const { source, ...options } = value;
+        this._textures.set(name, source, options);
+      }
+    }
+    return this;
+  }
+
+  /**
+   * Remove a texture.
+   */
+  removeTexture(name: string): this {
+    this._textures.delete(name);
+    return this;
+  }
+
+  /**
    * Compile and link shaders.
    * Errors are handled via onError callback, never thrown.
    */
@@ -234,10 +281,11 @@ export default class WebGL {
       // Link attributes to geometry
       this._geometry.linkAttributes(this._program);
 
-      // Attach program to uniforms for location caching
+      // Attach program to uniforms and textures for location caching
       const webglProgram = this._program.getProgram();
       if (webglProgram) {
         this._uniforms.attachProgram(webglProgram);
+        this._textures.attachProgram(webglProgram);
       }
 
       // Call onLoad callback after successful shader setup
@@ -336,6 +384,7 @@ export default class WebGL {
     this._geometry.destroy();
     this._program.destroy();
     this._uniforms.destroy();
+    this._textures.destroy();
     this.onAfterHooks.destroy();
     this.onBeforeHooks.destroy();
     RUNTIME_MODULES.clear();
@@ -368,6 +417,9 @@ export default class WebGL {
 
     // Upload all other uniforms
     this._uniforms.uploadAll();
+
+    // Upload textures
+    this._textures.uploadAll();
 
     // Draw geometry
     this._geometry.bind();

--- a/src/types.ts
+++ b/src/types.ts
@@ -31,6 +31,8 @@ export interface SandboxOptions {
   uniforms?: UniformSchema;
   /** Configure used modules behavior */
   modules?: Record<string, Record<string, AnyUniformValue>>;
+  /** Initial textures to bind */
+  textures?: TextureSchema;
 }
 
 /** Resolved sandbox options with all defaults applied */
@@ -156,6 +158,47 @@ export type DrawMode = "TRIANGLES" | "TRIANGLE_STRIP" | "TRIANGLE_FAN";
 
 /** Render callback signature */
 export type HookCallback = (clock: ClockState) => void | false;
+
+/** Valid texture source types */
+export type TextureSource =
+  | HTMLImageElement
+  | HTMLCanvasElement
+  | HTMLVideoElement
+  | ImageBitmap
+  | ImageData
+  | OffscreenCanvas;
+
+/** Texture wrapping mode */
+export type TextureWrap = "clamp" | "repeat" | "mirror";
+
+/** Texture filter mode */
+export type TextureFilter = "nearest" | "linear";
+
+/** Per-texture configuration */
+export interface TextureOptions {
+  /** Wrapping mode for both axes (shorthand for wrapS + wrapT) */
+  wrap?: TextureWrap;
+  /** Wrapping mode for S (horizontal) axis */
+  wrapS?: TextureWrap;
+  /** Wrapping mode for T (vertical) axis */
+  wrapT?: TextureWrap;
+  /** Minification filter */
+  minFilter?: TextureFilter;
+  /** Magnification filter */
+  magFilter?: TextureFilter;
+  /** Flip texture vertically on upload (default: true) */
+  flipY?: boolean;
+  /** Re-upload pixels every frame for animated sources (default: true for video, false otherwise) */
+  dynamic?: boolean;
+}
+
+/** Resolved texture options with all defaults applied */
+export type ResolvedTextureOptions = Required<TextureOptions>;
+
+/** Schema for defining multiple textures at once */
+export interface TextureSchema {
+  [name: string]: TextureSource | ({ source: TextureSource } & TextureOptions);
+}
 
 /** GLSL uniform types */
 export type GLSLType =


### PR DESCRIPTION
- **Textures** — full `sampler2D` support via `setTexture()` / `setTextures()`. Handles images, canvas, video, and ImageBitmap sources. Per-texture options for wrap, filter, flip. Video sources auto-update every frame (`dynamic: true`), configurable for animated canvases too.
- **Frame export** — `exportAsURL()`, `exportAsBlob()`, `exportAsImage()` for screenshots, thumbnails, and server uploads.
- **Streaming** — `stream()` returns a `MediaStream` for WebRTC video calls and `MediaRecorder` workflows.

Closes #5